### PR TITLE
fix "Error: unterminated string parsing" on distribute build for windows

### DIFF
--- a/distribute/windows/EnvVarUpdate.nsh
+++ b/distribute/windows/EnvVarUpdate.nsh
@@ -43,7 +43,7 @@
   !ifndef Un${StrFuncName}_INCLUDED
     ${Un${StrFuncName}}
   !endif
-  !define un.${StrFuncName} "${Un${StrFuncName}}"
+  !define un.${StrFuncName} '${Un${StrFuncName}}'
 !macroend
 
 !insertmacro _IncludeStrFunction StrTok


### PR DESCRIPTION
It's the first time I setup a development environment for VisiCut. I followed the developer guide and installed everything on Linux Mint 20.2

Error:
```
# ./distribute
Determining Version (may be overridden with environment variable VERSION):
Version is: "1.9-121-g423e50d3+devel"
Building jar...
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Your driver does not implement saveJob(LaserJob job)
Warning: Cannot test driver de.thomas_oster.liblasercut.drivers.SampleDriver because it does not support saveJob()
Your driver does not implement saveJob(LaserJob job)
Warning: Cannot test driver de.thomas_oster.liblasercut.drivers.K3EngraverDriver because it does not support saveJob()
ScriptingSecurity: LaserScript tried to access forbidden class: org
ScriptingSecurity: LaserScript tried to access forbidden class: com
ScriptingSecurity: LaserScript tried to access forbidden class: edu
ScriptingSecurity: LaserScript tried to access forbidden class: net
ScriptingSecurity: LaserScript tried to access forbidden class: java.io.FileWriter
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Removing leftover files
Copying content...
Downloading OpenJRE for Windows (may be overridden with WINDOWS_JRE_URL and WINDOWS_JRE_SHA256)
--2021-09-10 13:21:44--  https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.4_11.zip
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://github-releases.githubusercontent.com/140419044/68b39700-a962-11e9-8d18-5291f62d550d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210910%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210910T112144Z&X-Amz-Expires=300&X-Amz-Signature=e117f6ffbeff3cf203ed589c42a019cb9780abcc0d3b5faca636d536e34af24d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=140419044&response-content-disposition=attachment%3B%20filename%3DOpenJDK11U-jre_x64_windows_hotspot_11.0.4_11.zip&response-content-type=application%2Foctet-stream [following]
--2021-09-10 13:21:44--  https://github-releases.githubusercontent.com/140419044/68b39700-a962-11e9-8d18-5291f62d550d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20210910%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20210910T112144Z&X-Amz-Expires=300&X-Amz-Signature=e117f6ffbeff3cf203ed589c42a019cb9780abcc0d3b5faca636d536e34af24d&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=140419044&response-content-disposition=attachment%3B%20filename%3DOpenJDK11U-jre_x64_windows_hotspot_11.0.4_11.zip&response-content-type=application%2Foctet-stream
Resolving github-releases.githubusercontent.com (github-releases.githubusercontent.com)... 2606:50c0:8000::154, 2606:50c0:8001::154, 2606:50c0:8003::154, ...
Connecting to github-releases.githubusercontent.com (github-releases.githubusercontent.com)|2606:50c0:8000::154|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 41944487 (40M) [application/octet-stream]
Saving to: ‘cache/jre.zip’

cache/jre.zip                 100%[===============================================>]  40,00M  5,81MB/s    in 6,8s    

2021-09-10 13:21:52 (5,89 MB/s) - ‘cache/jre.zip’ saved [41944487/41944487]

Building Windows launcher and installer
Error: unterminated string parsing line at macro:_IncludeStrFunction:7
Error in macro _IncludeStrFunction on macroline 7
!include: error in script: "EnvVarUpdate.nsh" on line 49
Error in script "installer.nsi" on line 13 -- aborting creation process
```

I am not familiar with building stuff for windows this way, but I found a fix on stackoverflow (https://stackoverflow.com/questions/62081765/how-to-debug-nsis-script-3-05-2-gives-error-error-unterminated-string-parsing) which works for me. Please check if that fix is appropriate or if I missed something.
